### PR TITLE
Add codecov service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,6 @@ after_success: |
   make install DESTDIR=../../kcov-build &&
   cd ../.. &&
   rm -rf kcov-master &&
-  for file in target/debug/examplerust-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+  for file in target/debug/eden-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
   bash <(curl -s https://codecov.io/bash) &&
   echo "Uploaded code coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ addons:
       - libdw-dev
       - binutils-dev
       - libsodium-dev
+      - cmake
+      - gcc
+      - libiberty-dev
 
 before_script:
   - |
@@ -35,9 +38,19 @@ before_script:
       ./configure --prefix=$HOME --with-libsodium
       make && make install
       cd $TRAVIS_BUILD_DIR
-  - which cargo-coveralls || cargo install cargo-travis
 
-after_success:
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
-      cargo coveralls --all --verbose;
-    fi
+
+after_success: |
+  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+  tar xzf master.tar.gz &&
+  cd kcov-master &&
+  mkdir build &&
+  cd build &&
+  cmake .. &&
+  make &&
+  make install DESTDIR=../../kcov-build &&
+  cd ../.. &&
+  rm -rf kcov-master &&
+  for file in target/debug/examplerust-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+  bash <(curl -s https://codecov.io/bash) &&
+  echo "Uploaded code coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 dist: trusty
 language: rust
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eden
 
-[![Build Status](https://travis-ci.org/NotBad4U/eden.svg?branch=master)](https://travis-ci.org/NotBad4U/eden)
+[![Build Status](https://travis-ci.org/NotBad4U/eden.svg?branch=master)](https://travis-ci.org/NotBad4U/eden) [![codecov](https://codecov.io/gh/NotBad4U/eden/branch/master/graph/badge.svg)](https://codecov.io/gh/NotBad4U/eden)
 
 A Multi-Agent distributed System ([MAS](https://en.wikipedia.org/wiki/Multi-agent_system)) in rust based on channel communication (`Zeromq`,`std::Channel`) and written in Data-oriented design.
 


### PR DESCRIPTION
Use [codecov.io](https://codecov.io/) to host the code coverage.